### PR TITLE
ci: replace nightly with 1.11, add formatter check, pin RegisterAction, add heavy test workflow, clean stale branches

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - 'nightly'
+          - '1.11'
         os:
           - ubuntu-latest
         arch:
@@ -37,6 +37,14 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Check formatting
+        shell: julia --color=yes {0}
+        run: |
+          using JuliaFormatter
+          format(".")
+          if !isempty(read(`git diff --name-only`, String))
+            error("Code is not properly formatted. Run JuliaFormatter.format(\".\") and commit.")
+          end
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/HeavyTests.yml
+++ b/.github/workflows/HeavyTests.yml
@@ -1,0 +1,29 @@
+name: Heavy Tests
+on:
+  workflow_dispatch:
+    inputs:
+      heavy_timeout:
+        description: Timeout in minutes for the heavy test job
+        required: true
+        default: "120"
+jobs:
+  heavy-tests:
+    name: Heavy Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(inputs.heavy_timeout) }}
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.11'
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: Run heavy dataset tests
+        shell: julia --color=yes --project=. {0}
+        run: |
+          ENV["RUN_HEAVY_TESTS"] = "1"
+          include("test/FunSQLTest.jl")

--- a/.github/workflows/Register.yml
+++ b/.github/workflows/Register.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
         contents: write
     steps:
-      - uses: julia-actions/RegisterAction@latest
+      - uses: julia-actions/RegisterAction@v0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- **Replace Julia `nightly` with `1.11`** in the CI test matrix to avoid flaky failures from nightly builds
- **Add JuliaFormatter check step** to CI — enforces Blue style per `.JuliaFormatter.toml`; fails the build if any file is unformatted
- **Pin `RegisterAction@latest` to `@v0.3`** in `Register.yml` for reproducible builds
- **Add `HeavyTests.yml` workflow** — `workflow_dispatch` only (manual trigger), runs the 19.1 GB FunSQL dataset integration tests with a configurable timeout (default 120 min)
- **Delete 13 stale `compathelper/*` remote branches** (Oct 2025–May 2026) that were cluttering the remote