### PR TITLE
Dependencies & build cleanup

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,4 +1,0 @@
-[deps]
-trl = ""
-datasets = ""
-transformers = ""

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HealthLLM"
 uuid = "1de6b779-c1fb-4125-b891-fad447459241"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["ParamThakkar123 <paramthakkar864@gmail.com> and TheCedarPrince <jacobszelko@gmail.com>"]
 
 [deps]
@@ -8,7 +8,6 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DrWatson = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 DuckDB = "d2f5444f-75bc-4fdf-ac35-56f514c445e1"
 FunSQL = "cf6cc811-59f4-4a10-b258-a8547a8f6407"
-HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 HuggingFaceHub = "d0076355-e2c0-48e6-a044-05906e51b7fc"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LibPQ = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
@@ -37,7 +36,8 @@ Statistics = "1.10"
 julia = "1.10"
 
 [extras]
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["HTTP", "Test"]


### PR DESCRIPTION
## Summary

- **Move HTTP to [extras]** — HTTP was only used in `test/FunSQLTest.jl`, not in source code. Moved from `[deps]` to `[extras]` and added to the `test` target.
- **Remove CondaPkg.toml** — Listed `trl`, `datasets`, `transformers` with no Python/Conda bridge code in the package. Deleted the file.
- **Bump version 0.0.1 → 0.1.0** — Package has accumulated significant functionality across many iterations.